### PR TITLE
Add Microsoft.Win32.Registry package

### DIFF
--- a/Eavesdrop/Eavesdrop.csproj
+++ b/Eavesdrop/Eavesdrop.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It was accidentally removed in the previous .NET 5.0 upgrade, causing build fail.