### PR TITLE
Fix couple disposable patterns and .NETify naming

### DIFF
--- a/Eavesdrop/Eavesdropper.cs
+++ b/Eavesdrop/Eavesdropper.cs
@@ -117,7 +117,7 @@ public static class Eavesdropper
         HttpResponseMessage? response = null;
         HttpContent? originalResponseContent = null;
 
-        HttpRequestMessage request = await local.ReceiveHTTPRequestAsync().ConfigureAwait(false);
+        HttpRequestMessage request = await local.ReceiveHttpRequestAsync().ConfigureAwait(false);
         HttpContent? originalRequestContent = request.Content;
         try
         {
@@ -132,7 +132,7 @@ public static class Eavesdropper
             await OnResponseInterceptedAsync(responseArgs).ConfigureAwait(false);
             if (responseArgs.Cancel) return;
 
-            await local.SendHTTPResponseAsync(response).ConfigureAwait(false);
+            await local.SendHttpResponseAsync(response).ConfigureAwait(false);
         }
         finally
         {
@@ -149,8 +149,8 @@ public static class Eavesdropper
         INETOptions.Overrides.Clear();
         INETOptions.IsIgnoringLocalTraffic = false;
 
-        INETOptions.HTTPAddress = null;
-        INETOptions.HTTPSAddress = null;
+        INETOptions.HttpAddress = null;
+        INETOptions.HttpsAddress = null;
         INETOptions.IsProxyEnabled = false;
 
         INETOptions.Save();
@@ -160,11 +160,11 @@ public static class Eavesdropper
         string address = "127.0.0.1:" + port;
         if (interceptors.HasFlag(Interceptors.HTTP))
         {
-            INETOptions.HTTPAddress = address;
+            INETOptions.HttpAddress = address;
         }
         if (interceptors.HasFlag(Interceptors.HTTPS))
         {
-            INETOptions.HTTPSAddress = address;
+            INETOptions.HttpsAddress = address;
         }
         INETOptions.IsProxyEnabled = true;
         INETOptions.IsIgnoringLocalTraffic = true;

--- a/Eavesdrop/Internals/INETOptions.cs
+++ b/Eavesdrop/Internals/INETOptions.cs
@@ -14,8 +14,8 @@ public static class INETOptions
 
     public static HashSet<string> Overrides { get; }
 
-    public static string? HTTPAddress { get; set; }
-    public static string? HTTPSAddress { get; set; }
+    public static string? HttpAddress { get; set; }
+    public static string? HttpsAddress { get; set; }
 
     public static bool IsProxyEnabled { get; set; }
     public static bool IsIgnoringLocalTraffic { get; set; }
@@ -124,8 +124,8 @@ public static class INETOptions
             string[] pair = value.Split('=');
             if (pair.Length != 2)
             {
-                HTTPAddress = value;
-                HTTPSAddress = value;
+                HttpAddress = value;
+                HttpsAddress = value;
                 return;
             }
 
@@ -133,8 +133,8 @@ public static class INETOptions
             string protocol = pair[0];
             switch (protocol)
             {
-                case "http": HTTPAddress = address; break;
-                case "https": HTTPSAddress = address; break;
+                case "http": HttpAddress = address; break;
+                case "https": HttpsAddress = address; break;
             }
         }
     }
@@ -142,8 +142,8 @@ public static class INETOptions
     private static string GetJoinedAddresses()
     {
         return string.Join(";",
-            !string.IsNullOrWhiteSpace(HTTPAddress) ? $"http={HTTPAddress}" : string.Empty,
-            !string.IsNullOrWhiteSpace(HTTPSAddress) ? $"https={HTTPSAddress}" : string.Empty);
+            !string.IsNullOrWhiteSpace(HttpAddress) ? $"http={HttpAddress}" : string.Empty,
+            !string.IsNullOrWhiteSpace(HttpsAddress) ? $"https={HttpsAddress}" : string.Empty);
     }
     private static string GetJoinedOverrides()
     {

--- a/Eavesdrop/Network/HTTP/BufferedHTTPContent.cs
+++ b/Eavesdrop/Network/HTTP/BufferedHTTPContent.cs
@@ -1,15 +1,15 @@
 ﻿using System.Net;
 using System.Buffers;
 
-namespace Eavesdrop.Network.HTTP;
+namespace Eavesdrop.Network.Http;
 
-public sealed class BufferedHTTPContent : HttpContent
+public sealed class BufferedHttpContent : HttpContent
 {
     private readonly IMemoryOwner<byte> _contentBufferOwner;
 
     public Memory<byte> Memory { get; }
 
-    public BufferedHTTPContent(int minBufferSize = -1)
+    public BufferedHttpContent(int minBufferSize = -1)
     {
         _contentBufferOwner = MemoryPool<byte>.Shared.Rent(minBufferSize);
 

--- a/Eavesdrop/Network/HTTP/BufferedHTTPSegment.cs
+++ b/Eavesdrop/Network/HTTP/BufferedHTTPSegment.cs
@@ -1,14 +1,14 @@
 ﻿using System.Buffers;
 
-namespace Eavesdrop.Network.HTTP;
+namespace Eavesdrop.Network.Http;
 
-public sealed class BufferedHTTPSegment : ReadOnlySequenceSegment<byte>, IDisposable
+public sealed class BufferedHttpSegment : ReadOnlySequenceSegment<byte>, IDisposable
 {
     private bool _disposed;
 
     private readonly IMemoryOwner<byte> _bufferOwner;
 
-    public BufferedHTTPSegment(int minBufferSize, out Memory<byte> buffer)
+    public BufferedHttpSegment(int minBufferSize, out Memory<byte> buffer)
     {
         _bufferOwner = MemoryPool<byte>.Shared.Rent(minBufferSize);
 
@@ -18,12 +18,12 @@ public sealed class BufferedHTTPSegment : ReadOnlySequenceSegment<byte>, IDispos
 
     public void Collapse()
     {
-        (Next as BufferedHTTPSegment)?.Dispose();
+        (Next as BufferedHttpSegment)?.Dispose();
         Next = null;
     }
-    public BufferedHTTPSegment Grow(int minBufferSize, out Memory<byte> buffer)
+    public BufferedHttpSegment Grow(int minBufferSize, out Memory<byte> buffer)
     {
-        var httpSegment = new BufferedHTTPSegment(minBufferSize, out buffer)
+        var httpSegment = new BufferedHttpSegment(minBufferSize, out buffer)
         {
             RunningIndex = RunningIndex + Memory.Length
         };
@@ -34,17 +34,12 @@ public sealed class BufferedHTTPSegment : ReadOnlySequenceSegment<byte>, IDispos
 
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-    private void Dispose(bool disposing)
-    {
-        if (_disposed) return;
-        if (disposing)
+        if (!_disposed)
         {
             _bufferOwner?.Dispose();
-            (Next as BufferedHTTPSegment)?.Dispose();
+            (Next as BufferedHttpSegment)?.Dispose();
+
+            _disposed = true;
         }
-        _disposed = true;
     }
 }

--- a/Eavesdrop/Network/HTTP/HTTPResponseWriter.cs
+++ b/Eavesdrop/Network/HTTP/HTTPResponseWriter.cs
@@ -1,8 +1,8 @@
 ﻿using System.Buffers;
 
-namespace Eavesdrop.Network.HTTP;
+namespace Eavesdrop.Network.Http;
 
-public sealed class HTTPResponseWriter : IBufferWriter<byte>, IDisposable
+public sealed class HttpResponseWriter : IBufferWriter<byte>, IDisposable
 {
     private bool _disposed;
     private IMemoryOwner<byte> _bufferOwner;
@@ -10,7 +10,7 @@ public sealed class HTTPResponseWriter : IBufferWriter<byte>, IDisposable
     public int Written { get; private set; }
     public Memory<byte> Memory { get; private set; }
 
-    public HTTPResponseWriter(int minBufferSize = -1)
+    public HttpResponseWriter(int minBufferSize = -1)
     {
         _bufferOwner = MemoryPool<byte>.Shared.Rent(minBufferSize);
         Memory = _bufferOwner.Memory;

--- a/Eavesdrop/Network/HTTP/UnbufferedHTTPContent.cs
+++ b/Eavesdrop/Network/HTTP/UnbufferedHTTPContent.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net;
 
-namespace Eavesdrop.Network.HTTP;
+namespace Eavesdrop.Network.Http;
 
-internal sealed class UnbufferedHTTPContent : HttpContent
+internal sealed class UnbufferedHttpContent : HttpContent
 {
     protected override bool TryComputeLength(out long length) { length = 0; return false; }
     protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) => Task.CompletedTask;


### PR DESCRIPTION
* For sealed classes that inherit IDisposable, you don't need GC.SuppressFinalizer and the Dispose(bool) pattern
* Renamed "HTTP" to "Http" which is the .NET naming convention.