### PR TITLE
Add initial support for cancellation and other minor refactoring

### DIFF
--- a/Eavesdrop.CLI/Eavesdrop.CLI.csproj
+++ b/Eavesdrop.CLI/Eavesdrop.CLI.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Eavesdrop\Eavesdrop.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Eavesdrop\Eavesdrop.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Eavesdrop/CertificateManager.cs
+++ b/Eavesdrop/CertificateManager.cs
@@ -189,13 +189,12 @@ public sealed class CertificateManager : IDisposable
         return certificates.Count > 0 ? certificates : null;
     }
 
-    public void Dispose() => Dispose(true);
-    private void Dispose(bool disposing)
+    public void Dispose()
     {
-        if (disposing)
-        {
-            _myStore.Close();
-            _rootStore.Close();
-        }
+        _myStore.Close();
+        _rootStore.Close();
+
+        _myStore.Dispose();
+        _rootStore.Dispose();
     }
 }

--- a/Eavesdrop/Eavesdrop.csproj
+++ b/Eavesdrop/Eavesdrop.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net6.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Eavesdrop/Network/EavesNode.cs
+++ b/Eavesdrop/Network/EavesNode.cs
@@ -3,11 +3,9 @@ using System.Text;
 using System.Buffers;
 using System.Net.Sockets;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
 using Eavesdrop.Network.Http;
-using System;
 
 namespace Eavesdrop.Network;
 

--- a/Eavesdrop/Network/EavesNode.cs
+++ b/Eavesdrop/Network/EavesNode.cs
@@ -7,6 +7,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
 using Eavesdrop.Network.Http;
+using System;
 
 namespace Eavesdrop.Network;
 
@@ -39,7 +40,7 @@ public sealed class EavesNode : IDisposable
         _stream = new NetworkStream(client, true);
     }
 
-    public async Task<HttpRequestMessage> ReceiveHttpRequestAsync()
+    public async Task<HttpRequestMessage> ReceiveHttpRequestAsync(CancellationToken cancellationToken = default)
     {
         using var firstBufferedHttpSegment = new BufferedHttpSegment(MINIMUM_HTTP_BUFFER_SIZE, out Memory<byte> buffer);
         BufferedHttpSegment lastBufferedHttpSegment = firstBufferedHttpSegment;
@@ -48,7 +49,7 @@ public sealed class EavesNode : IDisposable
         HttpRequestMessage? request = null;
         while (_client.Connected && _stream.CanRead && request == null)
         {
-            int bytesRead = await _stream.ReadAsync(buffer).ConfigureAwait(false);
+            int bytesRead = await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             if (!TryParseHttpRequest(firstBufferedHttpSegment, lastBufferedHttpSegment, baseUri, bytesRead, out request, out int unconsumedBytes))
             {
                 lastBufferedHttpSegment = lastBufferedHttpSegment.Grow(MINIMUM_HTTP_BUFFER_SIZE, out buffer);
@@ -57,7 +58,7 @@ public sealed class EavesNode : IDisposable
 
             if (request?.Method == _connectMethod && request.RequestUri != null)
             {
-                await SendHttpResponseAsync(_okResponse).ConfigureAwait(false);
+                await SendHttpResponseAsync(_okResponse, cancellationToken).ConfigureAwait(false);
 
                 X509Certificate2? certificate = _certifier.GenerateCertificate(request.RequestUri.DnsSafeHost);
                 if (certificate == null)
@@ -65,9 +66,14 @@ public sealed class EavesNode : IDisposable
                     throw new NullReferenceException($"Failed to generate a self-signed certificate for '{request.RequestUri.DnsSafeHost}'.");
                 }
 
-                var secureStream = new SslStream(_stream);
-                await secureStream.AuthenticateAsServerAsync(certificate, false, SslProtocols.None, false).ConfigureAwait(false);
-                _stream = secureStream;
+                var sslStream = new SslStream(_stream);
+                var sslOptions = new SslServerAuthenticationOptions()
+                {
+                    ServerCertificate = certificate
+                };
+
+                await sslStream.AuthenticateAsServerAsync(sslOptions, cancellationToken).ConfigureAwait(false);
+                _stream = sslStream;
 
                 baseUri = request.RequestUri;
                 request.Dispose();
@@ -80,13 +86,13 @@ public sealed class EavesNode : IDisposable
             {
                 int unconsumedStart = buffer.Length - unconsumedBytes;
                 ReadOnlyMemory<byte> unconsumed = lastBufferedHttpSegment.Memory.Slice(unconsumedStart, bytesRead - unconsumedStart);
-                await BufferHttpRequestContentAsync(request, unconsumed, _stream).ConfigureAwait(false);
+                await BufferHttpRequestContentAsync(request, unconsumed, _stream, cancellationToken).ConfigureAwait(false);
             }
         }
 
         return request ?? throw new NullReferenceException("Failed to parse the HTTP request.");
     }
-    public async Task SendHttpResponseAsync(HttpResponseMessage response)
+    public async Task SendHttpResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
     {
         using var responseWriter = new HttpResponseWriter(MINIMUM_HTTP_BUFFER_SIZE);
 
@@ -111,12 +117,12 @@ public sealed class EavesNode : IDisposable
         }
 
         responseWriter.AppendLine();
-        await responseWriter.WriteToAsync(_stream).ConfigureAwait(false);
+        await responseWriter.WriteToAsync(_stream, cancellationToken).ConfigureAwait(false);
         if (response.Content == null || response.Content == _okResponse.Content) return;
 
         if (response.Headers.TransferEncodingChunked == true)
         {
-            using Stream chunkedEncodingStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            using Stream chunkedEncodingStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using IMemoryOwner<byte> chunkedBufferOwner = MemoryPool<byte>.Shared.Rent(MINIMUM_HTTP_BUFFER_SIZE);
 
             var chunkHeadBuffer = new byte[6];
@@ -127,26 +133,26 @@ public sealed class EavesNode : IDisposable
             Memory<byte> chunkedBuffer = chunkedBufferOwner.Memory;
             do
             {
-                bytesRead = await chunkedEncodingStream.ReadAsync(chunkedBuffer).ConfigureAwait(false);
+                bytesRead = await chunkedEncodingStream.ReadAsync(chunkedBuffer, cancellationToken).ConfigureAwait(false);
 
                 int hexWritten = Encoding.UTF8.GetBytes(bytesRead.ToString("X"), chunkHeadBuffer);
-                await _stream.WriteAsync(chunkHeadBuffer, 0, hexWritten).ConfigureAwait(false);
-                await _stream.WriteAsync(chunkHeadBuffer, 4, 2).ConfigureAwait(false);
+                await _stream.WriteAsync(chunkHeadBuffer.AsMemory(0, hexWritten), cancellationToken).ConfigureAwait(false);
+                await _stream.WriteAsync(chunkHeadBuffer.AsMemory(4, 2), cancellationToken).ConfigureAwait(false);
 
                 if (bytesRead > 0)
                 {
-                    await _stream.WriteAsync(chunkedBuffer.Slice(0, bytesRead)).ConfigureAwait(false);
+                    await _stream.WriteAsync(chunkedBuffer.Slice(0, bytesRead), cancellationToken).ConfigureAwait(false);
                 }
-                await _stream.WriteAsync(chunkHeadBuffer, 4, 2).ConfigureAwait(false);
+                await _stream.WriteAsync(chunkHeadBuffer.AsMemory(4, 2), cancellationToken).ConfigureAwait(false);
             }
             while (bytesRead > 0);
         }
-        else await response.Content.CopyToAsync(_stream).ConfigureAwait(false);
+        else await response.Content.CopyToAsync(_stream, cancellationToken).ConfigureAwait(false);
 
-        await _stream.FlushAsync().ConfigureAwait(false);
+        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task BufferHttpRequestContentAsync(HttpRequestMessage request, ReadOnlyMemory<byte> bufferedContent, Stream stream)
+    private static async Task BufferHttpRequestContentAsync(HttpRequestMessage request, ReadOnlyMemory<byte> bufferedContent, Stream stream, CancellationToken cancellationToken = default)
     {
         if (request.Content == null)
         {
@@ -172,7 +178,7 @@ public sealed class EavesNode : IDisposable
 
         while (totalBytesRead < minBufferSize)
         {
-            totalBytesRead += await stream.ReadAsync(content.Memory.Slice(totalBytesRead)).ConfigureAwait(false);
+            totalBytesRead += await stream.ReadAsync(content.Memory.Slice(totalBytesRead), cancellationToken).ConfigureAwait(false);
         }
     }
     private static bool TryParseHttpRequest(BufferedHttpSegment first, BufferedHttpSegment last, Uri? baseUri, int lastBytesRead, out HttpRequestMessage? request, out int unconsumedBytes)

--- a/Eavesdrop/Network/EavesNode.cs
+++ b/Eavesdrop/Network/EavesNode.cs
@@ -16,9 +16,11 @@ public sealed class EavesNode : IDisposable
 
     private static readonly HttpMethod _connectMethod;
     private static readonly HttpResponseMessage _okResponse;
-    private static readonly byte[] _eolBytes = new byte[2] { (byte)'\r', (byte)'\n' };
-    private static readonly byte[] _eofBytes = new byte[4] { (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
-    private static readonly byte[] _connectBytes = new byte[7] { (byte)'C', (byte)'O', (byte)'N', (byte)'N', (byte)'E', (byte)'C', (byte)'T' };
+    
+    // TODO-FUTURE: In C# 11 use raw string literals
+    private static ReadOnlySpan<byte> _eolBytes => new byte[2] { (byte)'\r', (byte)'\n' };
+    private static ReadOnlySpan<byte> _eofBytes => new byte[4] { (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
+    private static ReadOnlySpan<byte> _connectBytes => new byte[7] { (byte)'C', (byte)'O', (byte)'N', (byte)'N', (byte)'E', (byte)'C', (byte)'T' };
 
     private readonly Socket _client;
     private readonly CertificateManager _certifier;

--- a/Eavesdrop/Network/Http/HttpResponseWriter.cs
+++ b/Eavesdrop/Network/Http/HttpResponseWriter.cs
@@ -34,7 +34,7 @@ public sealed class HttpResponseWriter : IBufferWriter<byte>, IDisposable
             _bufferOwner.Dispose();
             _bufferOwner = bufferOwner;
         }
-        return Memory.Slice(Written).Span;
+        return Memory.Span.Slice(Written);
     }
     public void Advance(int count) => Written += count;
     public Memory<byte> GetMemory(int sizeHint = 0) => throw new NotImplementedException();

--- a/Eavesdrop/Network/Http/HttpResponseWriter.cs
+++ b/Eavesdrop/Network/Http/HttpResponseWriter.cs
@@ -16,10 +16,10 @@ public sealed class HttpResponseWriter : IBufferWriter<byte>, IDisposable
         Memory = _bufferOwner.Memory;
     }
 
-    public async Task WriteToAsync(Stream stream)
+    public async Task WriteToAsync(Stream stream, CancellationToken cancellationToken = default)
     {
-        await stream.WriteAsync(Memory.Slice(0, Written)).ConfigureAwait(false);
-        await stream.FlushAsync().ConfigureAwait(false);
+        await stream.WriteAsync(Memory.Slice(0, Written), cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         Written = 0;
     }
 


### PR DESCRIPTION
* Changed the TFM to `net6.0-windows`. This removes most of the platform unsupported warnings by analyzers and this is library does not support any other OS.
* Add initial support for `CancellationToken` on almost every async method. For now there is no CancellationTokenSource hooked to it. 
* Fix the `IDisposable` pattern for `sealed CertificateManager`
* Fixed the static data fields in `EavesNode`
* Other minor refactoring.