### PR TITLE
Small clean-up

### DIFF
--- a/Eavesdrop/Eavesdrop.csproj
+++ b/Eavesdrop/Eavesdrop.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net6.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<LangVersion>preview</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Eavesdrop/Native/INETOptionList.cs
+++ b/Eavesdrop/Native/INETOptionList.cs
@@ -7,7 +7,7 @@ namespace Eavesdrop;
 /// </summary>
 /// <remarks>INTERNET_PER_CONN_OPTION_LIST structure (wininet.h)</remarks>
 [StructLayout(LayoutKind.Sequential)]
-internal unsafe struct INETOptionList
+internal unsafe ref struct INETOptionList
 {
     /// <summary>
     /// Size of the structure, in bytes.

--- a/Eavesdrop/Native/INETOptions.cs
+++ b/Eavesdrop/Native/INETOptions.cs
@@ -59,8 +59,7 @@ public static class INETOptions
 
                 fixed (INETOption* optionsPtr = options)
                 {
-                    Span<INETOptionList> inetOptionList = stackalloc INETOptionList[1];
-                    inetOptionList[0] = new INETOptionList
+                    INETOptionList inetOptionList = new()
                     {
                         Size = sizeof(INETOptionList),
                         Connection = null,
@@ -69,16 +68,13 @@ public static class INETOptions
                         OptionsPtr = optionsPtr
                     };
 
-                    fixed (INETOptionList* optionListPtr = inetOptionList)
+                    if (!NativeMethods.InternetSetOption(null, INTERNET_OPTION_PER_CONNECTION_OPTION, &inetOptionList, sizeof(INETOptionList)))
                     {
-                        if (!NativeMethods.InternetSetOption(null, INTERNET_OPTION_PER_CONNECTION_OPTION, optionListPtr, sizeof(INETOptionList)))
-                        {
-                            throw new Win32Exception(Marshal.GetLastWin32Error());
-                        }
-                        
-                        NativeMethods.InternetSetOption(null, INTERNET_OPTION_SETTINGS_CHANGED, optionListPtr, sizeof(INETOptionList));
-                        NativeMethods.InternetSetOption(null, INTERNET_OPTION_REFRESH, optionListPtr, sizeof(INETOptionList));
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
                     }
+
+                    NativeMethods.InternetSetOption(null, INTERNET_OPTION_SETTINGS_CHANGED, &inetOptionList, sizeof(INETOptionList));
+                    NativeMethods.InternetSetOption(null, INTERNET_OPTION_REFRESH, &inetOptionList, sizeof(INETOptionList));
                 }
             } 
         }

--- a/Eavesdrop/Network/EavesNode.cs
+++ b/Eavesdrop/Network/EavesNode.cs
@@ -16,10 +16,9 @@ public sealed class EavesNode : IDisposable
     private static readonly HttpMethod _connectMethod = new("CONNECT");
     private static readonly HttpResponseMessage _okResponse = new(HttpStatusCode.OK);
 
-    // TODO-FUTURE: In C# 11, use raw string literals
-    private static ReadOnlySpan<byte> _eolBytes => new byte[2] { (byte)'\r', (byte)'\n' };
-    private static ReadOnlySpan<byte> _eofBytes => new byte[4] { (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
-    private static ReadOnlySpan<byte> _connectBytes => new byte[7] { (byte)'C', (byte)'O', (byte)'N', (byte)'N', (byte)'E', (byte)'C', (byte)'T' };
+    private static ReadOnlySpan<byte> _eolBytes => "\r\n"u8;
+    private static ReadOnlySpan<byte> _eofBytes => "\r\n\r\n"u8;
+    private static ReadOnlySpan<byte> _connectBytes => "CONNECT"u8;
 
     private readonly Socket _client;
     private readonly CertificateManager _certifier;


### PR DESCRIPTION
Enable C# 11 preview features and use UTF-8 string literals in EavesNode. I also simplified the recently refactored interop logic a tiny bit.