### PR TITLE
Add initial test infrastructure

### DIFF
--- a/Eavesdrop.Tests/EavesNodeTests.cs
+++ b/Eavesdrop.Tests/EavesNodeTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text;
+using System.Net.Sockets;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+using Eavesdrop.Network;
+
+namespace Eavesdrop.Tests;
+
+public class EavesNodeTests
+{
+    private sealed class SelfSignedCertifier : ICertifier
+    {
+        public X509Certificate2? GenerateCertificate(string certificateName)
+        {
+            using var rsa = RSA.Create(1024);
+
+            var certificateRequest = new CertificateRequest($"CN={certificateName}, O=EavesNodeTest", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            certificateRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+            certificateRequest.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(certificateRequest.PublicKey, false));
+
+            using X509Certificate2 certificate = certificateRequest.CreateSelfSigned(DateTime.Now, DateTime.Now.AddDays(1));
+
+            certificate.FriendlyName = certificateName;
+            return new X509Certificate2(certificate.Export(X509ContentType.Pfx));
+        }
+    }
+
+    public async Task<(Socket Client, Socket Server)> CreateConnectedPairAsync()
+    {
+        using Socket listener = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen();
+
+        var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        await client.ConnectAsync(listener.LocalEndPoint!);
+        var server = await listener.AcceptAsync();
+
+        return (client, server);
+    }
+
+    public async Task<SslStream> AuthenticateAsClientAsync(Stream clientStream, string hostname, 
+        RemoteCertificateValidationCallback? validationCallback = default)
+    {
+        await clientStream.WriteAsync(Encoding.UTF8.GetBytes($"CONNECT {hostname}:443 HTTP/1.1\r\n\r\n"));
+        await clientStream.FlushAsync();
+
+        byte[] okBytesBuffer = new byte[32];
+        int read = await clientStream.ReadAsync(okBytesBuffer);
+
+        string okResponse = Encoding.UTF8.GetString(okBytesBuffer[..read]);
+        Assert.Equal("HTTP/1.1 200 OK\r\n\r\n", okResponse);
+
+        var sslClientStream = new SslStream(clientStream, false,
+            new RemoteCertificateValidationCallback(static (_, _, _, _) => true));
+
+        await sslClientStream.AuthenticateAsClientAsync(hostname, null, false);
+        Assert.True(sslClientStream.IsAuthenticated);
+
+        return sslClientStream;
+    }
+
+    [Fact]
+    public async Task InterceptGetRequest_Http_RequestLineWithAbsoluteUri()
+    {
+        var (client, server) = await CreateConnectedPairAsync();
+
+        using var node = new EavesNode(server, null);
+        using var clientStream = new NetworkStream(client, true);
+
+        await clientStream.WriteAsync("GET http://example.com/foo HTTP/1.1\r\nHost: example.com\r\n\r\n"u8.ToArray());
+
+        var request = await node.ReceiveHttpRequestAsync();
+        
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal(HttpVersion.Version11, request.Version);
+        Assert.Equal("http://example.com/foo", request.RequestUri?.ToString());
+    }
+
+    [Fact]
+    public async Task InterceptGetRequest_Https_RequestLineWithRelativePath()
+    {
+        var emptyCertifier = new SelfSignedCertifier();
+        var (client, server) = await CreateConnectedPairAsync();
+
+        using var node = new EavesNode(server, emptyCertifier);
+        using var clientStream = new NetworkStream(client, true);
+
+        Task<HttpRequestMessage> serverReceiveTask = node.ReceiveHttpRequestAsync();
+
+        using var sslClientStream = await AuthenticateAsClientAsync(clientStream, "example.com");
+        await sslClientStream.WriteAsync("GET /foo HTTP/1.1\r\nHost: example.com\r\n\r\n"u8.ToArray());
+
+        var request = await serverReceiveTask;
+
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal(HttpVersion.Version11, request.Version);
+        Assert.Equal("https://example.com/foo", request.RequestUri?.ToString());
+    }
+}

--- a/Eavesdrop.Tests/Eavesdrop.Tests.csproj
+++ b/Eavesdrop.Tests/Eavesdrop.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>preview</LangVersion>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Eavesdrop\Eavesdrop.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Eavesdrop.Tests/Usings.cs
+++ b/Eavesdrop.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Eavesdrop.sln
+++ b/Eavesdrop.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eavesdrop", "Eavesdrop\Eavesdrop.csproj", "{BF141F7D-B694-4B8E-8799-CA33856EE564}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eavesdrop.CLI", "Eavesdrop.CLI\Eavesdrop.CLI.csproj", "{7302CBDB-755D-4656-ABF4-C0A06DBD5538}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eavesdrop.CLI", "Eavesdrop.CLI\Eavesdrop.CLI.csproj", "{7302CBDB-755D-4656-ABF4-C0A06DBD5538}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eavesdrop.Tests", "Eavesdrop.Tests\Eavesdrop.Tests.csproj", "{4F238A21-BC00-4E01-9FD8-B5129AB55637}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{7302CBDB-755D-4656-ABF4-C0A06DBD5538}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7302CBDB-755D-4656-ABF4-C0A06DBD5538}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7302CBDB-755D-4656-ABF4-C0A06DBD5538}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F238A21-BC00-4E01-9FD8-B5129AB55637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F238A21-BC00-4E01-9FD8-B5129AB55637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F238A21-BC00-4E01-9FD8-B5129AB55637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F238A21-BC00-4E01-9FD8-B5129AB55637}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Eavesdrop/CertificateManager.cs
+++ b/Eavesdrop/CertificateManager.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Eavesdrop;
 
-public sealed class CertificateManager : IDisposable
+public sealed class Certifier : ICertifier, IDisposable
 {
     private readonly X509Store _rootStore, _myStore;
     private readonly IDictionary<string, X509Certificate2> _certificateCache;
@@ -18,16 +18,16 @@ public sealed class CertificateManager : IDisposable
 
     public X509Certificate2? Authority { get; private set; }
 
-    public CertificateManager()
+    public Certifier()
         : this("Eavesdrop")
     { }
-    public CertificateManager(string issuer)
+    public Certifier(string issuer)
         : this(issuer, $"{issuer} Root Certificate Authority", StoreLocation.CurrentUser)
     { }
-    public CertificateManager(string issuer, string certificateAuthorityName)
+    public Certifier(string issuer, string certificateAuthorityName)
         : this(issuer, certificateAuthorityName, StoreLocation.CurrentUser)
     { }
-    public CertificateManager(string issuer, string certificateAuthorityName, StoreLocation location)
+    public Certifier(string issuer, string certificateAuthorityName, StoreLocation location)
     {
         _myStore = new X509Store(StoreName.My, location);
         _rootStore = new X509Store(StoreName.Root, location);
@@ -67,9 +67,7 @@ public sealed class CertificateManager : IDisposable
     }
     public X509Certificate2 CreateCertificate(string subjectName, string alternateName)
     {
-        using var rsa = Authority == null
-            ? new RSACryptoServiceProvider(KeyLength)
-            : new RSACryptoServiceProvider(KeyLength, new CspParameters(1, "Microsoft Base Cryptographic Provider v1.0", Guid.NewGuid().ToString()));
+        using var rsa = RSA.Create(KeyLength);
 
         var certificateRequest = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         if (Authority == null)

--- a/Eavesdrop/Eavesdropper.cs
+++ b/Eavesdrop/Eavesdropper.cs
@@ -40,7 +40,7 @@ public static class Eavesdropper
     }
 
     public static bool IsRunning { get; private set; }
-    public static CertificateManager Certifier { get; set; }
+    public static Certifier Certifier { get; set; }
 
     static Eavesdropper()
     {
@@ -52,7 +52,7 @@ public static class Eavesdropper
         _httpClientHandler.CheckCertificateRevocationList = false;
         _httpClientHandler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
-        Certifier = new CertificateManager("Eavesdrop", "Eavesdrop Root Certificate Authority");
+        Certifier = new Certifier("Eavesdrop", "Eavesdrop Root Certificate Authority");
     }
 
     public static void Terminate()
@@ -106,13 +106,13 @@ public static class Eavesdropper
         {
             while (IsRunning && _listener != null)
             {
-                Socket client = await _listener.AcceptAsync().ConfigureAwait(false);
-                _ = HandleClientAsync(client);
+                Socket socket = await _listener.AcceptAsync().ConfigureAwait(false);
+                _ = HandleSocketAsync(socket);
             }
         }
         catch { /* Catch all exceptions. */ }
     }
-    private static async Task HandleClientAsync(Socket client, CancellationToken cancellationToken = default)
+    private static async Task HandleSocketAsync(Socket client, CancellationToken cancellationToken = default)
     {
         using var local = new EavesNode(client, Certifier);
 

--- a/Eavesdrop/ICertifier.cs
+++ b/Eavesdrop/ICertifier.cs
@@ -1,0 +1,8 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Eavesdrop;
+
+public interface ICertifier
+{
+    X509Certificate2? GenerateCertificate(string certificateName);
+}


### PR DESCRIPTION
* Added Eavesdrop.Tests project which uses xUnit for testing with couple simple EavesNode tests. 
* Made parts of the Eavesdropper more testable with addition of `ICertifier` interface.
* Renamed `CertificateManager` to `Certifier` which inherits `ICertifier`.